### PR TITLE
Added self to $sceDelegate policy whitelist

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,9 @@
 import { CastLightBootstraper } from './castlight.bootstraper';
+import { CastlightUrlSerializer } from './castlight.urlserializer';
 import { CastlightComponent } from './castlight.component';
 import { NgModule }      from '@angular/core';
 import { BrowserModule, DOCUMENT } from '@angular/platform-browser';
+import { UrlSerializer } from '@angular/router';
 
 import { AppComponent }  from './app.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -14,6 +16,7 @@ import { AppRoutingModule } from './app-routing.module';
   declarations: [ AppComponent ],
   providers: [
     CastLightBootstraper,
+    { provide: UrlSerializer, useClass: CastlightUrlSerializer },
     {
       provide: DOCUMENT,
       useValue: document

--- a/src/app/castlight.bootstraper.ts
+++ b/src/app/castlight.bootstraper.ts
@@ -104,6 +104,7 @@ export class CastLightBootstraper {
               '$sceDelegateProvider',
               ($sceDelegateProvider: any) => {
                 $sceDelegateProvider.resourceUrlWhitelist([
+                  'self',
                   'https://m.den-signoff08.castlighthealth.com/**', 
                   'https://api.den-signoff08.castlighthealth.com/**', 
                   'https://saturn.us.castlighthealth.com/**', 

--- a/src/app/castlight.urlserializer.ts
+++ b/src/app/castlight.urlserializer.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { UrlTree, UrlSerializer, DefaultUrlSerializer } from '@angular/router';
 
 /*
-  DefaultUrlSerializer serializes the URL after the an AngularJS 1.5 widget
+  DefaultUrlSerializer serializes the URL after the AngularJS 1.5 widget
   serializes it. This confuses the embedded widget.
 
   Eg:
@@ -13,7 +13,7 @@ import { UrlTree, UrlSerializer, DefaultUrlSerializer } from '@angular/router';
     localhost/castlight##find-care%243Ftab=providers
       by Angular
 
-  The fix is convert '%3F' back to '?' before passing it across to Angular.
+  The fix is to convert '%3F' back to '?' before passing it across to Angular.
   And change '?' to '%3F' while serializing the UrlTree.
   */
 @Injectable()

--- a/src/app/castlight.urlserializer.ts
+++ b/src/app/castlight.urlserializer.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { UrlTree, UrlSerializer, DefaultUrlSerializer } from '@angular/router';
+
+/*
+  DefaultUrlSerializer serializes the URL after the an AngularJS 1.5 widget
+  serializes it. This confuses the embedded widget.
+
+  Eg:
+    localhost/castlight##find-care?tab=providers
+        gets converted to
+    localhost/castlight##find-care%3Ftab=providers
+      by AngularJS 1.5. This is then converted to
+    localhost/castlight##find-care%243Ftab=providers
+      by Angular
+
+  The fix is convert '%3F' back to '?' before passing it across to Angular.
+  And change '?' to '%3F' while serializing the UrlTree.
+  */
+@Injectable()
+export class CastlightUrlSerializer implements UrlSerializer {
+  private defaultUrlSerializer: DefaultUrlSerializer;
+
+  constructor() {
+    this.defaultUrlSerializer = new DefaultUrlSerializer();
+  }
+
+  parse(url: string): UrlTree {
+    // Put the '?' back
+    let processedUrl: string = url.replace(/%3F/i, '?');
+    return this.defaultUrlSerializer.parse(processedUrl);
+  }
+
+  serialize(tree: UrlTree): string {
+    // Encode '?'
+    return this.defaultUrlSerializer.serialize(tree).replace(/\?/, '%3F');
+  }
+}


### PR DESCRIPTION
I added `'self'` to the sceDelegatePolicy whitelist so that all templates get fetched from the template cache without raising an exception.

I'm not sure whether this fix works on the actual portal, but it worked for me locally when I ran my widget on localhost:8888 and the bootstrap application on localhost:9000. The reason why `self` was needed: some templates like layout ones are fetched from 8888 but the tooltip ones come from 9000.

`Error: [$sce:insecurl] Blocked loading resource from url not allowed by $sceDelegate policy.  URL: components/providers/quality-badge/quality-badge-detail.html
http://errors.angularjs.org/1.5.8/$sce/insecurl?p0=components%2Fproviders%2Fquality-badge%2Fquality-badge-detail.html
    at eval (http://localhost:9000/assets/scripts/internal_packages/angular/angular.js:68:12) [angular]
    at Object.getTrusted `